### PR TITLE
Increase k8s dashboard login token TTL

### DIFF
--- a/CHARTS.md
+++ b/CHARTS.md
@@ -8,7 +8,7 @@
 | `gerrit` | CGI | |
 | `jenkins` | [official](https://github.com/kubernetes/charts/tree/master/stable/jenkins) | unchanged |
 | `kube-prometheus` | CoreOS [prometheus-operator](https://github.com/coreos/prometheus-operator/tree/master/helm) | <ul><li>shuffled requirements into `./charts` dependencies</li><li>omitted `exporter-coredns` optional dep</li></ul> |
-| `kubernetes-dashboard` | [official](https://github.com/kubernetes/charts/tree/master/stable/kubernetes-dashboard) | unchanged |
+| `kubernetes-dashboard` | [official](https://github.com/kubernetes/charts/tree/master/stable/kubernetes-dashboard) | <ul><li>login token ttl increased from default 15 m to 24 h</li></ul> |
 | `nexus` | CGI | <ul><li>Docker image provided: extends official image with GitHub auth plugin</li></ul> |
 | `nfs-client-provisioner` | packaging of [`external-storage/nfs-client`](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client) | |
 | `nginx-ingress` | [official](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress) | unchanged |

--- a/kubernetes-dashboard/values.yaml
+++ b/kubernetes-dashboard/values.yaml
@@ -16,7 +16,8 @@ labels: {}
 
 ## Additional container arguments
 ##
-# extraArgs:
+extraArgs:
+  - --token-ttl=86400  # 24 hours
 #   - --enable-insecure-login
 #   - --system-banner="Welcome to Kubernetes"
 


### PR DESCRIPTION
The default value for this is 15 minutes, which is much too short if
you're monitoring a cluster with the dashboard rather than just checking
in from time to time. Changed to 24 hours.